### PR TITLE
MXCACHE-72 - Make mxcache plugin multithreaded

### DIFF
--- a/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/AbstractInstrumentatorMojo.java
+++ b/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/AbstractInstrumentatorMojo.java
@@ -24,7 +24,7 @@ import com.maxifier.mxcache.instrumentation.ClassDefinition;
  */
 public abstract class AbstractInstrumentatorMojo extends AbstractInstrumentator {
     private static final Instrumentator INSTRUMENTATOR = InstrumentatorProvider.getPreferredVersion();
-    private static final int MIN_FILES_PER_THREAD = 10;
+    private static final int MIN_FILES_PER_THREAD = 100;
     private static final int MAX_THREADS_PER_CORE = 2;
 
     protected void instrumentClasses(File path) throws MojoExecutionException {

--- a/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/InstrumentatorMojo.java
+++ b/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/InstrumentatorMojo.java
@@ -14,6 +14,7 @@ import java.io.File;
  *
  * @goal instrument
  * @phase process-classes
+ * @threadSafe
  * 
  */
 @SuppressWarnings ({ "JavaDoc" })

--- a/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/TestInstrumentatorMojo.java
+++ b/mxcache-maven-plugin/src/main/java/com/maxifier/mxcache/mavenplugin/TestInstrumentatorMojo.java
@@ -14,6 +14,7 @@ import java.io.File;
  *
  * @goal instrument-tests
  * @phase process-test-classes
+ * @threadSafe
  */
 @SuppressWarnings ({ "JavaDoc" })
 @PublicAPI


### PR DESCRIPTION
Mark MxCache maven plugin mojo as @threadSafe to prevent warnings during maven parallel build
Increase the threshold for parallel instrumentation (was: 10 files, now: 100 files)
