### PR TITLE
Reduce memory consumption of CleanableRegister

### DIFF
--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/CacheFactory.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/CacheFactory.java
@@ -63,6 +63,10 @@ public final class CacheFactory {
         return REGISTRY.getClassDependencyNode(clazz);
     }
 
+    public static DependencyNode getClassInstanceDependencyNode(Class<?> clazz) {
+        return REGISTRY.getClassInstanceDependencyNode(clazz);
+    }
+
     public static DependencyNode getTagDependencyNode(String tag) {
         return REGISTRY.getTagDependencyNode(tag);
     }

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/AbstractCacheManager.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/AbstractCacheManager.java
@@ -12,7 +12,6 @@ import com.maxifier.mxcache.provider.CacheDescriptor;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.impl.resource.DependencyTracker;
 import com.maxifier.mxcache.caches.Cache;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nullable;
 
@@ -104,25 +103,13 @@ public abstract class AbstractCacheManager implements CacheManager {
             res.add(CacheFactory.getGroupDependencyNode(group));
         }
         if (descriptor.isStatic()) {
-            // static cache is not invalidated when a superclass of declaring class is invalidated
+            // static cache is not invalidated when a superclass of declaring class is invalidated,
+            // so we put it to a separate node
             res.add(CacheFactory.getClassDependencyNode(ownerClass));
         } else {
-            Set<Class<?>> visitedClasses = new THashSet<Class<?>>();
-            addAllSuperClassesAndInterfaces(res, visitedClasses, ownerClass);
+            res.add(CacheFactory.getClassInstanceDependencyNode(ownerClass));
         }
         return res.isEmpty() ? null : res.toArray(new DependencyNode[res.size()]);
-    }
-
-    private static void addAllSuperClassesAndInterfaces(List<DependencyNode> res, Set<Class<?>> visitedClasses, Class<?> clazz) {
-        while (clazz != null && clazz != Object.class) {
-            if (visitedClasses.add(clazz)) {
-                res.add(CacheFactory.getClassDependencyNode(clazz));
-                for (Class<?> intf : clazz.getInterfaces()) {
-                    addAllSuperClassesAndInterfaces(res, visitedClasses, intf);
-                }
-            }
-            clazz = clazz.getSuperclass();
-        }
     }
 
     protected StatisticsModeEnum getStatisticsMode() {


### PR DESCRIPTION
Each class dependency node used to store a reference to each of its child class caches.
Now instead of adding caches to every parent class list a dependency is added.