### PR TITLE
Fix memory leak in dependency nodes

### DIFF
--- a/mxcache-generation/src/test/java/com/maxifier/mxcache/template/impl/PInlineDependencyCache.template
+++ b/mxcache-generation/src/test/java/com/maxifier/mxcache/template/impl/PInlineDependencyCache.template
@@ -32,6 +32,14 @@ public class #E#InlineDependencyCache extends #E#InlineCacheImpl implements Depe
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public #E#InlineDependencyCache(Object owner, #E#Calculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class #E#InlineDependencyCache extends #E#InlineCacheImpl implements Depe
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/BooleanInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/BooleanInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class BooleanInlineDependencyCache extends BooleanInlineCacheImpl impleme
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public BooleanInlineDependencyCache(Object owner, BooleanCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class BooleanInlineDependencyCache extends BooleanInlineCacheImpl impleme
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ByteInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ByteInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class ByteInlineDependencyCache extends ByteInlineCacheImpl implements De
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public ByteInlineDependencyCache(Object owner, ByteCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class ByteInlineDependencyCache extends ByteInlineCacheImpl implements De
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/CharacterInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/CharacterInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class CharacterInlineDependencyCache extends CharacterInlineCacheImpl imp
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public CharacterInlineDependencyCache(Object owner, CharacterCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class CharacterInlineDependencyCache extends CharacterInlineCacheImpl imp
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/FloatInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/FloatInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class FloatInlineDependencyCache extends FloatInlineCacheImpl implements 
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public FloatInlineDependencyCache(Object owner, FloatCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class FloatInlineDependencyCache extends FloatInlineCacheImpl implements 
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/IntInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/IntInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class IntInlineDependencyCache extends IntInlineCacheImpl implements Depe
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public IntInlineDependencyCache(Object owner, IntCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class IntInlineDependencyCache extends IntInlineCacheImpl implements Depe
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/LongInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/LongInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class LongInlineDependencyCache extends LongInlineCacheImpl implements De
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public LongInlineDependencyCache(Object owner, LongCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class LongInlineDependencyCache extends LongInlineCacheImpl implements De
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class ObjectInlineDependencyCache extends ObjectInlineCacheImpl implement
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public ObjectInlineDependencyCache(Object owner, ObjectCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class ObjectInlineDependencyCache extends ObjectInlineCacheImpl implement
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ShortInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ShortInlineDependencyCache.java
@@ -32,6 +32,14 @@ public class ShortInlineDependencyCache extends ShortInlineCacheImpl implements 
      */
     private Set<Reference<DependencyNode>> dependentNodes;
 
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
     private Reference<DependencyNode> selfReference;
 
     public ShortInlineDependencyCache(Object owner, ShortCalculatable calculable, MutableStatistics statistics) {
@@ -68,6 +76,26 @@ public class ShortInlineDependencyCache extends ShortInlineCacheImpl implements 
             dependentNodes = new THashSet<Reference<DependencyNode>>();
         }
         dependentNodes.add(node.getSelfReference());
+        cleanupIfNeeded();
+    }
+
+    private void cleanupIfNeeded() {
+        if (dependentNodes.size() >= cleanupThreshold) {
+            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = dependentNodes.size() * 2;
+        }
     }
 
     @Override


### PR DESCRIPTION
Dependency nodes should regularly cleanup their dependent nodes references in order to remove the ones that point to GC'ed dependents