### PR TITLE
Lazy SmartReferenceManager thread creation

### DIFF
--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectObjectTroveStorage.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectObjectTroveStorage.java
@@ -4,6 +4,8 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.storage.ObjectObjectStorage;
+import com.maxifier.mxcache.transform.SmartReferenceManager;
+
 import gnu.trove.map.hash.THashMap;
 
 /**
@@ -13,6 +15,11 @@ import gnu.trove.map.hash.THashMap;
  * @author Alexander Kochurov (alexander.kochurov@maxifier.com)
  */
 public class ObjectObjectTroveStorage<K> extends THashMap<K, Object> implements ObjectObjectStorage<K> {
+
+    public ObjectObjectTroveStorage() {
+        super();
+        SmartReferenceManager.switchOn();
+    }
 
     @Override
     public Object load(K key) {

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectObjectTroveStorage.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectObjectTroveStorage.java
@@ -17,7 +17,6 @@ import gnu.trove.map.hash.THashMap;
 public class ObjectObjectTroveStorage<K> extends THashMap<K, Object> implements ObjectObjectStorage<K> {
 
     public ObjectObjectTroveStorage() {
-        super();
         SmartReferenceManager.switchOn();
     }
 


### PR DESCRIPTION
Поток, создаваемый в SmartReferenceManager не нужен вообще.
Для обратной совместимости есть возможность включить его (см. конструктор ObjectObjectTroveStorage).