### PR TITLE
move dependency nodes to separate class & compact after remove elements from THashSet

### DIFF
--- a/mxcache-generation/src/test/java/com/maxifier/mxcache/template/impl/PInlineDependencyCache.template
+++ b/mxcache-generation/src/test/java/com/maxifier/mxcache/template/impl/PInlineDependencyCache.template
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class #E#InlineDependencyCache extends #E#InlineCacheImpl implements Depe
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class #E#InlineDependencyCache extends #E#InlineCacheImpl implements Depe
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class #E#InlineDependencyCache extends #E#InlineCacheImpl implements Depe
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/DependencyNodes.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/DependencyNodes.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2014 Maxifier Ltd. All Rights Reserved.
+ */
+package com.maxifier.mxcache.impl;
+
+import com.maxifier.mxcache.impl.resource.DependencyNode;
+
+import gnu.trove.set.hash.THashSet;
+
+import java.lang.ref.Reference;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author Created by Aleksey Tomin (aleksey.tomin@cxense.com) (2016-06-06)
+ */
+public class DependencyNodes extends THashSet<Reference<DependencyNode>> {
+    /**
+     * After delete (1-COMPACT_THRESHOLD)*100% elemetns from
+     */
+    private static final double COMPACT_THRESHOLD = 0.7;
+
+    /**
+     * Number of elements in dependentNodes after which all the set should be checked for the presence of
+     * references to GC'ed objects.
+     *
+     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
+     */
+    private int cleanupThreshold = 10;
+
+    public synchronized void visitDependantNodes(DependencyNode.Visitor visitor) {
+        for (Iterator<Reference<DependencyNode>> it = iterator(); it.hasNext();) {
+            Reference<DependencyNode> ref = it.next();
+            DependencyNode instance = ref.get();
+            if (instance != null) {
+                visitor.visit(instance);
+            } else {
+                it.remove();
+            }
+        }
+    }
+
+    public boolean add(Reference<DependencyNode> reference) {
+        boolean result = super.add(reference);
+        cleanupIfNeeded();
+        return result;
+    }
+
+    private void cleanupIfNeeded() {
+        if (size() >= cleanupThreshold) {
+            int oldSize = size();
+            for (Iterator<Reference<DependencyNode>> it = iterator(); it.hasNext(); ) {
+                if (it.next().get() == null) {
+                    it.remove();
+                }
+            }
+            // after delete elements compact greatly accelerates an element insertion into THashSet
+            if (size() < oldSize * COMPACT_THRESHOLD) {
+                compact();
+            }
+            // It's important to increase cleanup threshold according to the number of elements in a set
+            // in order to maintain the balance between CPU-overhead and memory-overhead
+
+            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
+            // small overhead and thus would not affect the asymptotic behaviour of operations.
+
+            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
+            // 2 * peak memory usage for alive elements.
+            cleanupThreshold = size() * 2;
+        }
+    }
+
+}

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/DependencyNodes.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/DependencyNodes.java
@@ -16,7 +16,7 @@ import java.util.Set;
  */
 public class DependencyNodes extends THashSet<Reference<DependencyNode>> {
     /**
-     * After delete (1-COMPACT_THRESHOLD)*100% elemetns from
+     * After delete (1-COMPACT_THRESHOLD)*100% elements from set
      */
     private static final double COMPACT_THRESHOLD = 0.7;
 
@@ -28,7 +28,7 @@ public class DependencyNodes extends THashSet<Reference<DependencyNode>> {
      */
     private int cleanupThreshold = 10;
 
-    public synchronized void visitDependantNodes(DependencyNode.Visitor visitor) {
+    public void visitDependantNodes(DependencyNode.Visitor visitor) {
         for (Iterator<Reference<DependencyNode>> it = iterator(); it.hasNext();) {
             Reference<DependencyNode> ref = it.next();
             DependencyNode instance = ref.get();

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/BooleanInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/BooleanInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class BooleanInlineDependencyCache extends BooleanInlineCacheImpl impleme
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class BooleanInlineDependencyCache extends BooleanInlineCacheImpl impleme
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class BooleanInlineDependencyCache extends BooleanInlineCacheImpl impleme
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ByteInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ByteInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class ByteInlineDependencyCache extends ByteInlineCacheImpl implements De
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class ByteInlineDependencyCache extends ByteInlineCacheImpl implements De
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class ByteInlineDependencyCache extends ByteInlineCacheImpl implements De
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/CharacterInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/CharacterInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class CharacterInlineDependencyCache extends CharacterInlineCacheImpl imp
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class CharacterInlineDependencyCache extends CharacterInlineCacheImpl imp
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class CharacterInlineDependencyCache extends CharacterInlineCacheImpl imp
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/DoubleInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/DoubleInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class DoubleInlineDependencyCache extends DoubleInlineCacheImpl implement
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class DoubleInlineDependencyCache extends DoubleInlineCacheImpl implement
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class DoubleInlineDependencyCache extends DoubleInlineCacheImpl implement
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/FloatInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/FloatInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class FloatInlineDependencyCache extends FloatInlineCacheImpl implements 
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class FloatInlineDependencyCache extends FloatInlineCacheImpl implements 
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class FloatInlineDependencyCache extends FloatInlineCacheImpl implements 
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/IntInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/IntInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class IntInlineDependencyCache extends IntInlineCacheImpl implements Depe
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class IntInlineDependencyCache extends IntInlineCacheImpl implements Depe
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class IntInlineDependencyCache extends IntInlineCacheImpl implements Depe
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/LongInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/LongInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class LongInlineDependencyCache extends LongInlineCacheImpl implements De
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class LongInlineDependencyCache extends LongInlineCacheImpl implements De
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class LongInlineDependencyCache extends LongInlineCacheImpl implements De
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ObjectInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class ObjectInlineDependencyCache extends ObjectInlineCacheImpl implement
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class ObjectInlineDependencyCache extends ObjectInlineCacheImpl implement
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class ObjectInlineDependencyCache extends ObjectInlineCacheImpl implement
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ShortInlineDependencyCache.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/caches/def/ShortInlineDependencyCache.java
@@ -4,10 +4,10 @@
 package com.maxifier.mxcache.impl.caches.def;
 
 import com.maxifier.mxcache.caches.*;
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.impl.MutableStatistics;
 import com.maxifier.mxcache.impl.resource.DependencyNode;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
 
 import javax.annotation.Nonnull;
 
@@ -30,15 +30,7 @@ public class ShortInlineDependencyCache extends ShortInlineCacheImpl implements 
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
@@ -50,15 +42,7 @@ public class ShortInlineDependencyCache extends ShortInlineCacheImpl implements 
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -73,29 +57,9 @@ public class ShortInlineDependencyCache extends ShortInlineCacheImpl implements 
     @Override
     public synchronized void trackDependency(DependencyNode node) {
         if (dependentNodes == null) {
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes =  new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     @Override

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/resource/AbstractDependencyNode.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/resource/AbstractDependencyNode.java
@@ -3,8 +3,9 @@
  */
 package com.maxifier.mxcache.impl.resource;
 
+import com.maxifier.mxcache.impl.DependencyNodes;
 import com.maxifier.mxcache.util.HashWeakReference;
-import gnu.trove.set.hash.THashSet;
+
 import javax.annotation.Nullable;
 
 import java.lang.ref.Reference;
@@ -17,30 +18,14 @@ public abstract class AbstractDependencyNode implements DependencyNode {
     /**
      * Set of dependent nodes. It may be null cause there is no need to allocate whole set for each node.
      */
-    private Set<Reference<DependencyNode>> dependentNodes;
-
-    /**
-     * Number of elements in dependentNodes after which all the set should be checked for the presence of
-     * references to GC'ed objects.
-     *
-     * This threshold is required in order to evict such references as they pollute memory and never GC'ed otherwise.
-     */
-    private int cleanupThreshold = 10;
+    private DependencyNodes dependentNodes;
 
     private Reference<DependencyNode> selfReference;
 
     @Override
     public synchronized void visitDependantNodes(Visitor visitor) {
         if (dependentNodes != null) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext();) {
-                Reference<DependencyNode> ref = it.next();
-                DependencyNode instance = ref.get();
-                if (instance != null) {
-                    visitor.visit(instance);
-                } else {
-                    it.remove();
-                }
-            }
+            dependentNodes.visitDependantNodes(visitor);
         }
     }
 
@@ -64,29 +49,9 @@ public abstract class AbstractDependencyNode implements DependencyNode {
         if (dependentNodes == null) {
             // this magic set is used to prevent memory leaks
             // it cleans up references to GC'ed nodes on rehash
-            dependentNodes = new THashSet<Reference<DependencyNode>>();
+            dependentNodes = new DependencyNodes();
         }
         dependentNodes.add(node.getSelfReference());
-        cleanupIfNeeded();
-    }
-
-    private void cleanupIfNeeded() {
-        if (dependentNodes.size() >= cleanupThreshold) {
-            for (Iterator<Reference<DependencyNode>> it = dependentNodes.iterator(); it.hasNext(); ) {
-                if (it.next().get() == null) {
-                    it.remove();
-                }
-            }
-            // It's important to increase cleanup threshold according to the number of elements in a set
-            // in order to maintain the balance between CPU-overhead and memory-overhead
-
-            // The cleanup has O(N) complexity, so doing this on addition of N new elements would lead to constant
-            // small overhead and thus would not affect the asymptotic behaviour of operations.
-
-            // The memory overhead could be significant but it's guaranteed that memory usage would not be more than
-            // 2 * peak memory usage for alive elements.
-            cleanupThreshold = dependentNodes.size() * 2;
-        }
     }
 
     protected static boolean equal(@Nullable Object a, @Nullable Object b) {


### PR DESCRIPTION
Данный фикс гарантировано не повышает потребление памяти, но решает проблему с деградацией job'ы Campaign в sync'е.
Конкретные действия (и коэфициент) подобраны эксперементально, исходя из поведения sync'а при активных перегрузках Campaign и потомков AbstractBuyingModel.

Вариант с созданием своего аналога THashSet ждёт героя. Или момента отказа от кэшей в сущностях- тогда всё это будет ненужно.