### PR TITLE
Add new dependency tracking strategy

### DIFF
--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/DependencyTracking.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/DependencyTracking.java
@@ -27,5 +27,9 @@ public enum DependencyTracking {
      * Each instance has it's own dependency tracking, if a single cache is marked as dirty only this cache
      * will be cleaned.
      */
-    INSTANCE
+    INSTANCE,
+    /**
+     * Cache NOT depending from any other caches. Only manual MxResource.writeEnd() clean.
+     */
+    RESOURCE
 }

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/AbstractCacheManager.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/AbstractCacheManager.java
@@ -63,8 +63,11 @@ public abstract class AbstractCacheManager implements CacheManager {
         }
 
         trackDependency = convertStatic(convertDefault(descriptor.getTrackDependency()));
-        explicitDependencies = getExplicitDependencies(descriptor, ownerClass, convertDefault(descriptor.getTrackAnnotatedDependency()));
-
+        if (trackDependency == DependencyTracking.RESOURCE) {
+            explicitDependencies = null;
+        } else {
+            explicitDependencies = getExplicitDependencies(descriptor, ownerClass, convertDefault(descriptor.getTrackAnnotatedDependency()));
+        }
         switch (trackDependency) {
             case NONE:
                 if (explicitDependencies == null) {
@@ -76,6 +79,7 @@ public abstract class AbstractCacheManager implements CacheManager {
             case STATIC:
                 staticNode = createStaticNode();
                 break;
+            case RESOURCE:
             case INSTANCE:
                 staticNode = null;
                 break;
@@ -149,6 +153,9 @@ public abstract class AbstractCacheManager implements CacheManager {
 
     private DependencyTracking convertStatic(DependencyTracking tracking) {
         if (descriptor.isResourceView()) {
+            if (tracking == DependencyTracking.RESOURCE) {
+                return DependencyTracking.RESOURCE;
+            }
             return DependencyTracking.INSTANCE;
         }
         if (descriptor.isStatic() && tracking == DependencyTracking.INSTANCE) {
@@ -219,6 +226,7 @@ public abstract class AbstractCacheManager implements CacheManager {
             case STATIC:
                 return staticNode;
             case INSTANCE:
+            case RESOURCE:
                 return createInstanceNode();
             default:
                 throw new UnsupportedOperationException("Unknown value: " + trackDependency);

--- a/mxcache-tests/src/test/java/com/maxifier/mxcache/test/ResourceDependencyTrackingUTest.java
+++ b/mxcache-tests/src/test/java/com/maxifier/mxcache/test/ResourceDependencyTrackingUTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2016 Maxifier Ltd. All Rights Reserved.
+ */
+package com.maxifier.mxcache.test;
+
+import static org.testng.Assert.assertEquals;
+
+import com.maxifier.mxcache.Cached;
+import com.maxifier.mxcache.DependencyTracking;
+import com.maxifier.mxcache.ResourceView;
+import com.maxifier.mxcache.StatisticsMode;
+import com.maxifier.mxcache.StatisticsModeEnum;
+import com.maxifier.mxcache.impl.resource.MxResourceFactory;
+import com.maxifier.mxcache.resource.MxResource;
+import com.maxifier.mxcache.resource.TrackDependency;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Created by Aleksey Tomin (aleksey.tomin@cxense.com) (2016-06-10)
+ */
+public class ResourceDependencyTrackingUTest {
+
+    @Test
+    public void testDependencyFromEntity() {
+        Entity e1 = new Entity("1", 11);
+        Entity e2 = new Entity("2", 21);
+        Service s = new Service();
+
+        assertEquals(s.getVal(e1), 11);
+        assertEquals(s.getVal(e2), 21);
+
+        e1.setValDirect(12);
+        assertEquals(s.getVal(e1), 11);
+        assertEquals(s.getVal(e2), 21);
+
+        e2.setVal(22);
+        assertEquals(s.getVal(e1), 11);
+        assertEquals(s.getVal(e2), 22);
+
+        e1.setVal(13);
+        assertEquals(s.getVal(e1), 13);
+        assertEquals(s.getVal(e2), 22);
+    }
+
+}
+
+class Entity {
+    private final MxResource res;
+
+    private int val;
+
+    Entity(String name, int val) {
+        this.res = MxResourceFactory.getResource("Entity#" + name);
+        this.val = val;
+    }
+
+    @Cached
+    @TrackDependency(DependencyTracking.RESOURCE)
+    @ResourceView
+    public int getVal() {
+        res.readStart();
+        try {
+            return val;
+        } finally {
+            res.readEnd();
+        }
+    }
+
+    public void setVal(int val) {
+        res.writeStart();
+        try {
+            this.val = val;
+        } finally {
+            res.writeEnd();
+        }
+    }
+
+    public void setValDirect(int val) {
+        this.val = val;
+    }
+}
+
+class Service {
+    @Cached
+    public int getVal(Entity entity) {
+        return entity.getVal();
+    }
+}
+


### PR DESCRIPTION
Идея в том, что "ресурс" на самом деле не является кэшем.
Т.е. от "ресурса" зависит что-то, но сам "ресурс" зависит только от значения.

Переведя все кэшированные сущностей значения на данный механизм мы полностью исключаем активную работу с THashSet - ресур не зависит ни от кого, поэтому ни у кого не будут заливаться пачки ссылок на сущности.
Это позволит избавиться от "настоящих" кэшей в сущностях, но при этом не трогать ресурсы.