### PR TITLE
Supporting JDK9+

### DIFF
--- a/mxcache-asm/pom.xml
+++ b/mxcache-asm/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.maxifier.mxcache</groupId>
     <artifactId>mxcache-asm</artifactId>
-    <version>5.0</version>
+    <version>7.1</version>
     <name>MxCache asm</name>
     <description>A repackage of ASM byte code manipulation library with some fixes from 3.3.
         All classes put into com.maxifier.mxcache.asm package.
@@ -71,6 +71,15 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
@@ -80,10 +89,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
-			<phase>package</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
@@ -108,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.4</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/AddInstanceInitializer.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/AddInstanceInitializer.java
@@ -22,7 +22,7 @@ public class AddInstanceInitializer extends ClassVisitor {
     private Type thisType;
 
     public AddInstanceInitializer(ClassVisitor cv, Method method) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM7, cv);
         this.method = method;
     }
 
@@ -35,7 +35,7 @@ public class AddInstanceInitializer extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(final int access, final String name, final String desc, String sign, String[] exceptions) {
         if (!Modifier.isStatic(access) && name.equals(CodegenHelper.CONSTRUCTOR_NAME)) {
-            return new AdviceAdapter(Opcodes.ASM5, super.visitMethod(access, name, desc, sign, exceptions), access, name, desc) {
+            return new AdviceAdapter(Opcodes.ASM7, super.visitMethod(access, name, desc, sign, exceptions), access, name, desc) {
                 @Override
                 protected void onMethodEnter() {
                     loadThis();

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/AddStaticInitializer.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/AddStaticInitializer.java
@@ -26,7 +26,7 @@ public class AddStaticInitializer extends ClassVisitor {
     private Type thisType;
 
     public AddStaticInitializer(ClassVisitor cv, Method method) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM7, cv);
         this.method = method;
     }
 

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedDetector.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedDetector.java
@@ -31,7 +31,7 @@ class CachedDetector extends ClassVisitor {
     private boolean alreadyInstrumented;
 
     public CachedDetector(ClassVisitor nextDetector) {
-        super(Opcodes.ASM5, nextDetector);
+        super(Opcodes.ASM7, nextDetector);
     }
 
     @Override
@@ -98,7 +98,7 @@ class CachedDetector extends ClassVisitor {
         private final int methodAccess;
 
         MethodDetector(MethodVisitor mv, String desc, Method method, int methodAccess) {
-            super(Opcodes.ASM5, mv);
+            super(Opcodes.ASM7, mv);
             this.desc = desc;
             this.method = method;
             this.methodAccess = methodAccess;
@@ -132,7 +132,7 @@ class CachedDetector extends ClassVisitor {
 
         private class CachedAnnotationVisitor extends AnnotationVisitor {
             CachedAnnotationVisitor() {
-                super(Opcodes.ASM5);
+                super(Opcodes.ASM7);
             }
 
             @Override
@@ -164,7 +164,7 @@ class CachedDetector extends ClassVisitor {
                 if (!name.equals("tags")) {
                     return null;
                 }
-                return new AnnotationVisitor(Opcodes.ASM5) {
+                return new AnnotationVisitor(Opcodes.ASM7) {
                     @Override
                     public void visit(String name, Object value) {
                         context.getTags().add((String) value);

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage.java
@@ -68,7 +68,7 @@ abstract class CachedInstrumentationStage extends SerialVersionUIDAdder implemen
     private final TIntObjectHashMap<Generator> instanceCleanMethods = new TIntObjectHashMap<Generator>();
 
     public CachedInstrumentationStage(InstrumentatorImpl instrumentator, ClassVisitor classWriter, ClassVisitor nextDetector) {
-        super(Opcodes.ASM5, classWriter);
+        super(Opcodes.ASM7, classWriter);
         this.instrumentator = instrumentator;
         this.detector = new CachedDetector(nextDetector);
     }

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage219.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage219.java
@@ -56,7 +56,7 @@ class CachedInstrumentationStage219 extends CachedInstrumentationStage {
 
     private class CacheRegistrator extends AdviceAdapter {
         public CacheRegistrator(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage229.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage229.java
@@ -63,7 +63,7 @@ class CachedInstrumentationStage229 extends CachedInstrumentationStage {
         private int contextIndex = -1;
 
         public CacheRegistrator(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage262.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedInstrumentationStage262.java
@@ -72,7 +72,7 @@ public class CachedInstrumentationStage262 extends CachedInstrumentationStage {
         private int contextIndex = -1;
 
         public CacheRegistrator(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedMethodVisitor.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/CachedMethodVisitor.java
@@ -82,7 +82,7 @@ class CachedMethodVisitor extends MxGeneratorAdapter {
                 if (paramTypeSort != Type.OBJECT && paramTypeSort != Type.ARRAY) {
                     throw new IllegalCachedClass("Primitive types can't have custom hashing strategy", classVisitor.getSourceFileName());
                 }
-                return new AnnotationVisitor(Opcodes.ASM5, super.visitParameterAnnotation(parameter, annotationClassInnerName, visible)) {
+                return new AnnotationVisitor(Opcodes.ASM7, super.visitParameterAnnotation(parameter, annotationClassInnerName, visible)) {
                     @Override
                     public void visit(String name, Object value) {
                         if ("value".equals(name)) {

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/InstrumentatorImpl.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/InstrumentatorImpl.java
@@ -144,7 +144,7 @@ public abstract class InstrumentatorImpl implements com.maxifier.mxcache.instrum
 
         List<InstrumentationStage> stages = new ArrayList<InstrumentationStage>();
         ClassVisitor visitor = classWriter;
-        ClassVisitor detector = new ClassVisitor(Opcodes.ASM5) {};
+        ClassVisitor detector = new ClassVisitor(Opcodes.ASM7) {};
 
         // instrumentation stages are stacked, last added is first passed to class reader
         for (StageFactory factory : activeFactories) {

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/ResourceDetector.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/ResourceDetector.java
@@ -43,7 +43,7 @@ public class ResourceDetector extends ClassVisitor {
     private boolean alreadyInstrumented;
 
     public ResourceDetector(ClassVisitor cv, boolean allowNonStatic) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM7, cv);
         this.allowNonStatic = allowNonStatic;
     }
 
@@ -101,7 +101,7 @@ public class ResourceDetector extends ClassVisitor {
         private final ResourceMethodContext context = new ResourceMethodContext();
 
         private MethodDetector(MethodVisitor mv, int access, Method method) {
-            super(Opcodes.ASM5, mv);
+            super(Opcodes.ASM7, mv);
             this.access = access;
             this.method = method;
         }
@@ -140,7 +140,7 @@ public class ResourceDetector extends ClassVisitor {
             private final List<MxField> orderedFields;
 
             public ResourceAnnotationVisitor(Set<MxField> fields, Set<MxField> fieldsToCheck, List<MxField> orderedFields) {
-                super(Opcodes.ASM5);
+                super(Opcodes.ASM7);
                 this.fields = fields;
                 this.fieldsToCheck = fieldsToCheck;
                 this.orderedFields = orderedFields;
@@ -175,7 +175,7 @@ public class ResourceDetector extends ClassVisitor {
 
             private class ResourceValueAnnotationVisitor extends AnnotationVisitor {
                 private ResourceValueAnnotationVisitor() {
-                    super(Opcodes.ASM5);
+                    super(Opcodes.ASM7);
                 }
 
                 @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/ResourceInstrumentationStage.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/ResourceInstrumentationStage.java
@@ -33,7 +33,7 @@ abstract class ResourceInstrumentationStage extends SerialVersionUIDAdder implem
     private final ResourceDetector detector;
 
     public ResourceInstrumentationStage(InstrumentatorImpl instrumentator, ClassVisitor cv, ClassVisitor nextDetector) {
-        super(Opcodes.ASM5, new AddInstanceInitializer(new AddStaticInitializer(cv, RESOURCE_STATIC_INITIALIZER_METHOD), RESOURCE_INITIALIZER_METHOD));
+        super(Opcodes.ASM7, new AddInstanceInitializer(new AddStaticInitializer(cv, RESOURCE_STATIC_INITIALIZER_METHOD), RESOURCE_INITIALIZER_METHOD));
         this.detector = createDetector(nextDetector);
         this.instrumentator = instrumentator;
     }

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyDetector.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyDetector.java
@@ -38,7 +38,7 @@ class UseProxyDetector extends ClassVisitor {
     }
 
     public UseProxyDetector(ClassVisitor nextDetector) {
-        super(Opcodes.ASM5, nextDetector);
+        super(Opcodes.ASM7, nextDetector);
     }
 
     @Override
@@ -76,7 +76,7 @@ class UseProxyDetector extends ClassVisitor {
         private boolean cached;
 
         public ProxyMethodDetector(MethodVisitor oldVisitor, Method method, int methodAccess) {
-            super(Opcodes.ASM5, oldVisitor);
+            super(Opcodes.ASM7, oldVisitor);
             this.method = method;
             this.methodAccess = methodAccess;
             context = new ProxiedMethodContext(id++, Modifier.isStatic(this.methodAccess), method);

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage.java
@@ -42,7 +42,7 @@ abstract class UseProxyInstrumentationStage extends ClassVisitor implements Inst
     private String sourceFileName;
 
     public UseProxyInstrumentationStage(InstrumentatorImpl instrumentator, ClassVisitor cv, ClassVisitor nextDetector) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM7, cv);
         this.instrumentator = instrumentator;
         detector = new UseProxyDetector(nextDetector);
     }
@@ -156,7 +156,7 @@ abstract class UseProxyInstrumentationStage extends ClassVisitor implements Inst
 
     private class ProxyFactoryStaticInitializer extends AdviceAdapter {
         public ProxyFactoryStaticInitializer(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage219.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage219.java
@@ -95,7 +95,7 @@ class UseProxyInstrumentationStage219 extends UseProxyInstrumentationStage {
 
     private class ProxyFactoryInitializer extends AdviceAdapter {
         public ProxyFactoryInitializer(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage229.java
+++ b/mxcache-instrumentator/src/main/java/com/maxifier/mxcache/instrumentation/current/UseProxyInstrumentationStage229.java
@@ -103,7 +103,7 @@ class UseProxyInstrumentationStage229 extends UseProxyInstrumentationStage {
         private int contextIndex = -1;
 
         public ProxyFactoryInitializer(MethodVisitor oldVisitor, int access, String name, String desc) {
-            super(Opcodes.ASM5, oldVisitor, access, name, desc);
+            super(Opcodes.ASM7, oldVisitor, access, name, desc);
         }
 
         @Override

--- a/mxcache-maven-plugin/pom.xml
+++ b/mxcache-maven-plugin/pom.xml
@@ -39,11 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                </configuration>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/mxcache-runtime/pom.xml
+++ b/mxcache-runtime/pom.xml
@@ -61,4 +61,23 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/wrapping/Wrapping.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/impl/wrapping/Wrapping.java
@@ -472,7 +472,7 @@ public final class Wrapping {
 
     private static final class WrapperMethodGenerator extends GeneratorAdapter {
         private WrapperMethodGenerator(int access, Method method, MethodVisitor mv) {
-            super(Opcodes.ASM5, mv, access, method.getName(), method.getDescriptor());
+            super(Opcodes.ASM7, mv, access, method.getName(), method.getDescriptor());
         }
 
         public void loadStorage(Type wrapperType, Type storageType) {

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/ClassGenerator.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/ClassGenerator.java
@@ -25,11 +25,11 @@ public class ClassGenerator extends ClassVisitor {
     private boolean endVisited;
 
     public ClassGenerator(int flags) {
-        super(Opcodes.ASM5, new SmartClassWriter(flags));
+        super(Opcodes.ASM7, new SmartClassWriter(flags));
     }
 
     public ClassGenerator(ClassReader classReader, int flags) {
-        super(Opcodes.ASM5, new SmartClassWriter(classReader, flags));
+        super(Opcodes.ASM7, new SmartClassWriter(classReader, flags));
     }
 
     public ClassGenerator(int access, String name, Class superType, Class... interfaces) {

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/MxGeneratorAdapter.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/MxGeneratorAdapter.java
@@ -50,25 +50,25 @@ public class MxGeneratorAdapter extends GeneratorAdapter {
     }
 
     public MxGeneratorAdapter(int access, Method method, Type thisClass, ClassVisitor cv) {
-        super(Opcodes.ASM5, cv.visitMethod(access, method.getName(), method.getDescriptor(), null, null), access, method.getName(), method.getDescriptor());
+        super(Opcodes.ASM7, cv.visitMethod(access, method.getName(), method.getDescriptor(), null, null), access, method.getName(), method.getDescriptor());
         this.thisClass = thisClass;
         isStatic = Modifier.isStatic(access);
     }
 
     public MxGeneratorAdapter(int access, Method method, MethodVisitor mv, Type thisClass) {
-        super(Opcodes.ASM5, mv, access, method.getName(), method.getDescriptor());
+        super(Opcodes.ASM7, mv, access, method.getName(), method.getDescriptor());
         this.thisClass = thisClass;
         isStatic = Modifier.isStatic(access);
     }
 
     public MxGeneratorAdapter(MethodVisitor mv, int access, Method method, Type thisClass) {
-        super(Opcodes.ASM5, mv, access, method.getName(), method.getDescriptor());
+        super(Opcodes.ASM7, mv, access, method.getName(), method.getDescriptor());
         this.thisClass = thisClass;
         isStatic = Modifier.isStatic(access);
     }
 
     public MxGeneratorAdapter(MethodVisitor mv, int access, String name, String desc, Type thisClass) {
-        super(Opcodes.ASM5, mv, access, name, desc);
+        super(Opcodes.ASM7, mv, access, name, desc);
         this.thisClass = thisClass;
         isStatic = Modifier.isStatic(access);
     }

--- a/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/NameFindVisitor.java
+++ b/mxcache-runtime/src/main/java/com/maxifier/mxcache/util/NameFindVisitor.java
@@ -13,7 +13,7 @@ class NameFindVisitor extends ClassVisitor {
     private String name;
 
     NameFindVisitor() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM7);
     }
 
     @Override

--- a/mxcache-tests/pom.xml
+++ b/mxcache-tests/pom.xml
@@ -62,4 +62,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.persistence</groupId>
+                    <artifactId>javax.persistence-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/mxcache-tests/src/test/java/com/maxifier/mxcache/benchmark/MxCacheBenchmark.java
+++ b/mxcache-tests/src/test/java/com/maxifier/mxcache/benchmark/MxCacheBenchmark.java
@@ -81,7 +81,7 @@ public class MxCacheBenchmark {
         return fact(value);
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int manualCache() {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -90,7 +90,7 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int staticManualCache() {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -99,7 +99,7 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int mxCache() {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -108,7 +108,7 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int mxCacheGuava() {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -117,7 +117,7 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int manualGuava() throws ExecutionException {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -126,7 +126,7 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public int staticMxCache() {
         int val = 0;
         for (int i = 0; i<1000; i++) {
@@ -135,14 +135,14 @@ public class MxCacheBenchmark {
         return val;
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public void cleanManualCache() {
         for (int i = 0; i<100; i++) {
             Arrays.fill(cache, null);
         }
     }
 
-    @GenerateMicroBenchmark
+    @Benchmark
     public void cleanMxCache() {
         for (int i = 0; i<100; i++) {
             MxCache.getCleaner().clearCacheByInstance(this);

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
             <dependency>
                 <groupId>com.maxifier.mxcache</groupId>
                 <artifactId>mxcache-asm</artifactId>
-                <version>5.0</version>
+                <version>7.1</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                 <!-- Benchmarking toolkit -->
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
-                <version>0.4.1</version>
+                <version>1.21</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,52 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.0</version>
+                        <configuration>
+                            <source>8</source>
+                            <target>8</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.persistence</groupId>
+                        <artifactId>javax.persistence-api</artifactId>
+                        <version>2.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                        <version>1.1</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <version>2.3.0</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,9 +243,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -301,7 +300,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -315,7 +314,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>

--- a/stubgen/src/main/java/com/maxifier/mxcache/stubgen/StubGen.java
+++ b/stubgen/src/main/java/com/maxifier/mxcache/stubgen/StubGen.java
@@ -109,7 +109,7 @@ public class StubGen {
                 for (JarEntry jarEntry : Collections.list(jar.entries())) {
                     if (jarEntry.getName().endsWith(".class")) {
                         ClassReader r = new ClassReader(IOUtils.toByteArray(jar.getInputStream(jarEntry)));
-                        r.accept(new ClassVisitor(Opcodes.ASM5) {
+                        r.accept(new ClassVisitor(Opcodes.ASM7) {
                             Type thisType;
 
                             @Override
@@ -138,7 +138,7 @@ public class StubGen {
                             @Override
                             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                                 methodUsed(thisType, name, desc);
-                                return new MethodVisitor(Opcodes.ASM5) {
+                                return new MethodVisitor(Opcodes.ASM7) {
                                     @Override
                                     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                                         methodUsed(Type.getObjectType(owner), name, desc);

--- a/stubgen/src/test/java/com/maxifier/mxcache/stubgen/TestStubGen.java
+++ b/stubgen/src/test/java/com/maxifier/mxcache/stubgen/TestStubGen.java
@@ -19,6 +19,7 @@ import java.lang.reflect.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -257,7 +258,7 @@ public class TestStubGen {
             // It's works on linux and macos. Didn't tested on Windows.
             String path = "file:" + paths[i];
             if (!path.endsWith(".jar")) {
-                path = path + "/";
+                path = path + File.pathSeparator;
             }
             urls[i] = new URL(path);
         }

--- a/stubgen/src/test/java/com/maxifier/mxcache/stubgen/TestStubGen.java
+++ b/stubgen/src/test/java/com/maxifier/mxcache/stubgen/TestStubGen.java
@@ -231,9 +231,8 @@ public class TestStubGen {
         return stubClassLoader.loadClass(cls.getName());
     }
 
-    private URLClassLoader getNonTestCL() {
-        URLClassLoader testCl = (URLClassLoader) getClass().getClassLoader();
-        return new URLClassLoader(testCl.getURLs(), testCl.getParent()) {
+    private URLClassLoader getNonTestCL() throws MalformedURLException {
+        return new URLClassLoader(getUrls(), getClass().getClassLoader().getParent()) {
             @Override
             protected Class<?> findClass(String name) throws ClassNotFoundException {
                 for (Class libClass : LIB_CLASSES) {
@@ -249,6 +248,20 @@ public class TestStubGen {
                 return super.findClass(name);
             }
         };
+    }
+
+    private URL[] getUrls() throws MalformedURLException {
+        String[] paths = System.getProperty("java.class.path").split(System.getProperty("path.separator"));
+        URL[] urls = new URL[paths.length];
+        for (int i = 0; i < paths.length; i++) {
+            // It's works on linux and macos. Didn't tested on Windows.
+            String path = "file:" + paths[i];
+            if (!path.endsWith(".jar")) {
+                path = path + "/";
+            }
+            urls[i] = new URL(path);
+        }
+        return urls;
     }
 
     private File createJar(Class... classes) throws IOException {


### PR DESCRIPTION
Собственно по коммитам всё видно:
- обновил JMH, т.к. старый не поддерживал.
- обновил плагины (заодно jdk6 стала дефолтной)
- добавил зависимости на вынесенные из JDK модули
- переписал тест с учётом изменённой структуры наследования (под виндой всё может и сломалось- негде проверить)